### PR TITLE
Install dependencies when running docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV MININOTE_PORT 3000
 
 COPY . /app/
 
+RUN cd /app && npm install
+
 RUN cd /app/mininote-frontend && \
     npm install && \
     npm run build && \


### PR DESCRIPTION
When I try to run the application with docker, only dependencies for the frontend are installed, and it fails to start on `docker run`. This PR makes it so the dependencies for the backend are also installed, which makes the application run as described in the README.