### PR TITLE
Anticipate user intent to leave or reload if there's unsaved changes

### DIFF
--- a/mininote-frontend/src/App.vue
+++ b/mininote-frontend/src/App.vue
@@ -63,6 +63,9 @@ export default {
     NotesPicker,
     ControlBar
   },
+  created(){
+    window.addEventListener("beforeunload", this.didIntentToLeave);
+  },
   methods: {
     onNoteSelected: function(noteId) {
       this.selectedNoteId = noteId
@@ -89,6 +92,14 @@ export default {
       setTimeout(function() {
         vm.alert = null
       }, 3000)
+    },
+    didIntentToLeave: function(event){
+      if(this.hasChanges){
+        // Cancel the event as stated by the standard.
+        event.preventDefault();
+        // Chrome requires returnValue to be set.
+        event.returnValue = '';
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #20.

Hi @n1try , i've added a event listener for the `window` instance. So, if the user intents to quit or reload the page, they will be notified with a popup. Glad to help!