### PR TITLE
Address Issue #13 and add basic https server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .vscode
 node_modules
 data/*.json*
+data/*.pem

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ A simple, self-hosted Markdown note-taking app built with [VueJS](https://vuejs.
 3. `docker run -d -p 3000:3000 -v /your-dir-of-choice:/app/data mininote`
 --> MiniNote will listen on port 3000 and persist data to `/your-dir-of-choice` on your host system using a shared volume.
 
+## Use HTTPS for backend
+1. Open `config.js`
+2. Edit the `HTTPS_KEY` and `HTTPS_CERT` field, and insert the file locations at which your private key and site certifications are stored.
+3. Launch the backend server
+--> To switch back to the HTTP server, nullify either field and relaunch again.
+
 ## Todo
 This project is still under development. The following features are about to be implemented. Feel free to contribute.
 * Tests

--- a/config.js
+++ b/config.js
@@ -2,5 +2,7 @@ module.exports = {
     PORT: process.env.MININOTE_PORT ? parseInt(process.env.MININOTE_PORT) : 3000,
     DB_FILE: 'data/notebooks.json',
     DB_COLLECTION_MAIN: 'notebooks',
-    DEBUG: false
+    DEBUG: false,
+    HTTPS_KEY: null,
+    HTTPS_CERT: null,
 }

--- a/index.js
+++ b/index.js
@@ -18,9 +18,11 @@ const config = require('./config'),
     debug = process.env.NODE_ENV === 'dev' || config.DEBUG
 
 let notebooks;
+let server;
 
 app.use(express.static('public'))
 app.use(bodyParser.json())
+
 if (debug) app.use(cors())
 
 app.head('/api/notebook/:id', (req, res) => {
@@ -67,7 +69,19 @@ app.put('/api/notebook/:id/settings', (req, res) => {
     res.send(notebook.notes)
 })
 
-app.listen(port, () => {
+if (config.HTTPS_KEY && config.HTTPS_CERT) {
+    const https = require('https'),
+        fs = require('fs'),
+        key = fs.readFileSync(config.HTTPS_KEY, 'utf8'),
+        cert = fs.readFileSync(config.HTTPS_CERT, 'utf8')
+
+    server = https.createServer({ key, cert }, app)
+} else {
+    const http = require('http')
+    server = http.createServer(app)
+}
+
+server.listen(port, () => {
     console.log(`Listening on localhost:${port}.`)
 })
 

--- a/index.js
+++ b/index.js
@@ -72,11 +72,16 @@ app.put('/api/notebook/:id/settings', (req, res) => {
 if (config.HTTPS_KEY && config.HTTPS_CERT) {
     const https = require('https'),
         fs = require('fs'),
-        key = fs.readFileSync(config.HTTPS_KEY, 'utf8'),
-        cert = fs.readFileSync(config.HTTPS_CERT, 'utf8')
+        path = require('path'),
+        key = fs.readFileSync(path.normalize(config.HTTPS_KEY), 'utf8'),
+        cert = fs.readFileSync(path.normalize(config.HTTPS_CERT), 'utf8')
 
-    server = https.createServer({ key, cert }, app)
-} else {
+    if (key && cert) {
+        server = https.createServer({ key, cert }, app)
+    }
+}
+
+if (!server) {
     const http = require('http')
     server = http.createServer(app)
 }


### PR DESCRIPTION
Address issue #13 and add support for express's https server.

Now if user adds file path to the http cert and private key files, the server will be launched with default support of the https encryption (aka using node's native https server).