### PR TITLE
Moved alert down to show control bar

### DIFF
--- a/mininote-frontend/src/App.vue
+++ b/mininote-frontend/src/App.vue
@@ -161,7 +161,7 @@ button {
 .alert {
   width: 500px;
   position: fixed;
-  top: 15px;
+  top: 65px;
   left: calc(50% - 250px);
   z-index: 999;
   text-align: center;


### PR DESCRIPTION
Slightly changed the CSS in App.vue to allow the control bar to bee seen when an alert is shown.

From
![old](https://i.postimg.cc/VLTf87cH/mininote-old.png)
to
![new](https://i.postimg.cc/6QZJfzkF/mininote.png)